### PR TITLE
Allow template to also be an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cfn makes the following Cloud Formation tasks simpler.
 ##### Cleanup Stacks
 * Use regex pattern to delete stacks.
 * Include `daysOld` to delete stacks this old.
-    
+
 ## Install
 ```
 $ npm install cfn --save-dev
@@ -22,7 +22,7 @@ $ npm install cfn --save-dev
 ## Usage
 
 ### Create / Update
-Use cfn to create or update a Cloud Formation stack.  It returns a promise.  You can use Node.js modules or standard 
+Use cfn to create or update a Cloud Formation stack.  It returns a promise.  You can use Node.js modules or standard
 json for Cloud Formation Templates.
 
 ```javascript
@@ -35,7 +35,7 @@ cfn('Foo-Bar', __dirname + '/template.js')
     .then(function() {
         console.log('done');
     });
-    
+
 // Create or update the Foo-Bar stack with the template.json json template.
 cfn('Foo-Bar', 'template.json');
 
@@ -55,7 +55,7 @@ Cleanup stacks based on regex and daysOld.
 ```javascript
 // Delete stacks starting with TEST- that are 3 days old or more
 cfn.cleanup({
-    regex: /TEST-/, 
+    regex: /TEST-/,
     minutesOld: 60
 })
     .then(function() {
@@ -93,7 +93,7 @@ Path to the template (js or json file).  This is optional and if given will over
 Name of stack
 
 ##### options.template
-Path to template (json or js file).  If the optional second argument is passed in it
+Path to template (json or js file), or a JSON object. If the optional second argument is passed in it
 will override this.
 
 ##### options.async
@@ -135,13 +135,12 @@ This allows you to pass any [config properties allowed by the AWS Node.js SDK](h
 cfn({
     name: 'Foo-Bar',
     template: _dirname + '/template.js',
-    awsConfig: { 
+    awsConfig: {
         region: 'us-west-2'
-        accessKeyId: 'akid', 
+        accessKeyId: 'akid',
         secretAccessKey: 'secret'
     }
 }).then(function() {
     console.log('done');
 });
 ```
-

--- a/index.js
+++ b/index.js
@@ -230,9 +230,25 @@ function Cfn(name, template) {
     }
 
     function processStack(action, name, template) {
-        return (_.endsWith(template, '.js')
-            ? loadJs(template)
-            : fs.readFileAsync(template, 'utf8'))
+        var promise;
+
+        switch (true) {
+            // Check if template if a `js` file
+            case _.endsWith(template, '.js'):
+                promise = loadJs(template);
+                break;
+
+            // Check if template is an object, assume this is JSON good to go
+            case _.isObjectLike(template):
+                promise = Promise.resolve(JSON.stringify(template));
+                break;
+
+            // Default to loading template from file.
+            default:
+                promise = fs.readFileAsync(template, 'utf8');
+        }
+
+        return promise
             .then(function (data) {
                 return processCfStack(action, {
                     StackName: name,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       "operator-linebreak": [
         "error",
         "before"
-      ]
+      ],
+      "no-use-extend-native/no-use-extend-native": "off"
     }
   },
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,17 @@ tape('Create / Update js function template', 'TEST-JS-FN-TEMPLATE', function (t)
         });
 });
 
+tape('Create / Update json string', 'TEST-JSON-STRING-TEMPLATE', function (t) {
+    return cfn('TEST-JSON-TEMPLATE', require(path.join(__dirname, '/templates/test-template-1.json')))
+        .then(function () {
+            return cf.describeStacksAsync({ StackName: 'TEST-JSON-TEMPLATE' });
+        })
+        .then(function (data) {
+            t.equal(data.Stacks[0].StackName, 'TEST-JSON-TEMPLATE', 'Stack Name Matches');
+            t.equal(data.Stacks[0].StackStatus, 'CREATE_COMPLETE', 'Stack Status is correct');
+        });
+});
+
 tape('Cleanup js stacks', function () {
     return cfn.cleanup(/TEST-JS-/);
 });


### PR DESCRIPTION
Thanks for `cfn`! I've found it to be excellent for my needs with a minimal API.

While using it, I found that many times I already have the JSON template ready to go, but I had to first save it to a file, invoke `cfn` and then unlink the temporary file.

I've made a small modification so objects are now accepted as a `template`. `cfn` will detect this and stringify them to prevent the interim "save-as-a-file" step. It makes the workflow a little simplier for me and I hope you like it too.

Sorry about the additional whitespace changes!