### PR TITLE
Add support for tagging templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "8"
   - "7"
   - "6"
-  - "4.3"
 script:
   - yarn test
 after_success:

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Use cfn to create or update an AWS CloudFormation stack.  It returns a promise. 
 json or yaml for AWS CloudFormation templates.
 
 ```javascript
-
 var cfn = require('cfn');
-
 
 // Create or update (if it exists) the Foo-Bar stack with the template.js Node.js module.
 cfn('Foo-Bar', __dirname + '/template.js')
@@ -40,11 +38,28 @@ cfn('Foo-Bar', __dirname + '/template.js')
         console.log('done');
     });
 
-// Create or update the Foo-Bar stack with the template.json json template.
+// json
 cfn('Foo-Bar', 'template.json');
 
-// Create or update the Foo-Bar2 stack with the template.yml yaml template.
+// yaml
 cfn('Foo-Bar2', 'template.yml');
+
+
+// Verbose Syntax
+cfn({
+  name: 'Foo-Bar',
+  template: 'template.yaml',
+  cfParams: {
+    buildNumber: '123',
+  },
+  tags: {
+    app: 'my app',
+    department: 'accounting',
+  },
+  awsConfig: {
+    region: 'us-east-2',
+  },
+});
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ cfn({
   },
   awsConfig: {
     region: 'us-east-2',
+    accessKeyId: 'akid',
+    secretAccessKey: 'secret',
   },
+  capabilities: ['CAPABILITY_IAM'],
+  checkStackInterval: 5000,
 });
 
 ```

--- a/index.js
+++ b/index.js
@@ -239,6 +239,8 @@ function Cfn (name, template) {
                 .catch(function (err) {
                   if (!/No updates are to be performed/.test(err)) {
                     throw err
+                  } else {
+                    log('No updates are to be performed.');
                   }
                 })
     }

--- a/index.js
+++ b/index.js
@@ -85,13 +85,13 @@ let _config = {
 function Cfn (name, template) {
   let log = console.log
   let opts = _.isPlainObject(name) ? name : {}
+  let awsOpts = {}
   let startedAt = Date.now()
   let params = opts.params
   let cfParams = opts.cfParams || {}
   let awsConfig = opts.awsConfig
   let capabilities = opts.capabilities || ['CAPABILITY_IAM']
   let tags = opts.tags || {}
-  let awsOpts = {}
   let async = opts.async
   let checkStackInterval = opts.checkStackInterval || _config.checkStackInterval
 

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function Cfn (name, template) {
                   if (!/No updates are to be performed/.test(err)) {
                     throw err
                   } else {
-                    log('No updates are to be performed.');
+                    log('No updates are to be performed.')
                   }
                 })
     }
@@ -267,7 +267,7 @@ function Cfn (name, template) {
     })
   }
 
-  function convertTags() {
+  function convertTags () {
     if (!_.isPlainObject(tags)) return []
     return (Object.keys(tags)).map(function (key) {
       return {

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ function Cfn (name, template) {
   let cfParams = opts.cfParams || {}
   let awsConfig = opts.awsConfig
   let capabilities = opts.capabilities || ['CAPABILITY_IAM']
+  let tags = opts.tags || {}
   let awsOpts = {}
   let async = opts.async
   let checkStackInterval = opts.checkStackInterval || _config.checkStackInterval
@@ -266,6 +267,16 @@ function Cfn (name, template) {
     })
   }
 
+  function convertTags() {
+    if (!_.isPlainObject(tags)) return []
+    return (Object.keys(tags)).map(function (key) {
+      return {
+        Key: key,
+        Value: tags[key]
+      }
+    })
+  }
+
   function isStringOfType (type, str) {
     let result = true
     try {
@@ -342,7 +353,8 @@ function Cfn (name, template) {
               return processCfStack(action, merge({
                 StackName: name,
                 Capabilities: capabilities,
-                Parameters: convertParams(cfParams)
+                Parameters: convertParams(cfParams),
+                Tags: convertTags()
               }, templateObject(data)))
             })
             .then(function () {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "Yun Wang (https://github.com/yunwang240)",
     "James Allen (https://github.com/jamesallen-vol)",
     "Brendan Abbott (https://github.com/brendo)",
-    "Robert Stettner (https://github.com/robertstettner)"
+    "Robert Stettner (https://github.com/robertstettner)",
+    "Kevin McGill (https://github.com/kmcgill88)"
   ],
   "homepage": "https://github.com/Nordstrom/cfn#readme",
   "standard": {

--- a/test/index.js
+++ b/test/index.js
@@ -100,7 +100,7 @@ describe('create/update', function () {
     var updateStackStub, createStackStub
     beforeEach(function () {
       AWS.restore()
-            // setup create/update stack stubs
+      // setup create/update stack stubs
       updateStackStub = AWS.mock('CloudFormation', 'updateStack', sinon.stub().callsArgWith(1, null, 'updated'))
       createStackStub = AWS.mock('CloudFormation', 'createStack', sinon.stub().callsArgWith(1, null, 'created'))
 
@@ -212,25 +212,25 @@ describe('create/update', function () {
             key: 'value'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.not.be.called()
-                      updateStackStub.stub.should.be.calledOnce()
-                      updateStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'TableName',
-                            ParameterValue: 'TestTable'
-                          }
-                        ],
-                        Tags: [
-                          {
-                            Key: 'key',
-                            Value: 'value'
-                          }
-                        ]
-                      })
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.not.be.called()
+          updateStackStub.stub.should.be.calledOnce()
+          updateStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'TableName',
+                ParameterValue: 'TestTable'
+              }
+            ],
+            Tags: [
+              {
+                Key: 'key',
+                Value: 'value'
+              }
+            ]
+          })
+          return data
+        })
       })
       it('updates stack from yaml template file with CloudFormation parameters AND empty tags when none passed', function () {
         var cfn = require('../')
@@ -241,20 +241,20 @@ describe('create/update', function () {
             TableName: 'TestTable'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.not.be.called()
-                      updateStackStub.stub.should.be.calledOnce()
-                      updateStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'TableName',
-                            ParameterValue: 'TestTable'
-                          }
-                        ],
-                        Tags: []
-                      })
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.not.be.called()
+          updateStackStub.stub.should.be.calledOnce()
+          updateStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'TableName',
+                ParameterValue: 'TestTable'
+              }
+            ],
+            Tags: []
+          })
+          return data
+        })
       })
       it('updates stack from js module file with module and CloudFormation parameters', function () {
         var cfn = require('../')

--- a/test/index.js
+++ b/test/index.js
@@ -200,6 +200,62 @@ describe('create/update', function () {
                       return data
                     })
       })
+      it('updates stack from yaml template file with CloudFormation parameters AND tags', function () {
+        var cfn = require('../')
+        return cfn({
+          name: 'TEST-YAML-TEMPLATE',
+          template: path.join(__dirname, '/templates/test-template-5.yml'),
+          cfParams: {
+            TableName: 'TestTable'
+          },
+          tags: {
+            key: 'value'
+          }
+        })
+                    .then(function (data) {
+                      createStackStub.stub.should.not.be.called()
+                      updateStackStub.stub.should.be.calledOnce()
+                      updateStackStub.stub.should.be.calledWithMatch({
+                        Parameters: [
+                          {
+                            ParameterKey: 'TableName',
+                            ParameterValue: 'TestTable'
+                          }
+                        ],
+                        Tags: [
+                          {
+                            Key: 'key',
+                            Value: 'value'
+                          }
+                        ],
+                      })
+                      return data
+                    })
+      })
+      it('updates stack from yaml template file with CloudFormation parameters AND empty tags when none passed', function () {
+        var cfn = require('../')
+        return cfn({
+          name: 'TEST-YAML-TEMPLATE',
+          template: path.join(__dirname, '/templates/test-template-5.yml'),
+          cfParams: {
+            TableName: 'TestTable'
+          },
+        })
+                    .then(function (data) {
+                      createStackStub.stub.should.not.be.called()
+                      updateStackStub.stub.should.be.calledOnce()
+                      updateStackStub.stub.should.be.calledWithMatch({
+                        Parameters: [
+                          {
+                            ParameterKey: 'TableName',
+                            ParameterValue: 'TestTable'
+                          }
+                        ],
+                        Tags: [],
+                      })
+                      return data
+                    })
+      })
       it('updates stack from js module file with module and CloudFormation parameters', function () {
         var cfn = require('../')
         return cfn({

--- a/test/index.js
+++ b/test/index.js
@@ -227,7 +227,7 @@ describe('create/update', function () {
                             Key: 'key',
                             Value: 'value'
                           }
-                        ],
+                        ]
                       })
                       return data
                     })
@@ -239,7 +239,7 @@ describe('create/update', function () {
           template: path.join(__dirname, '/templates/test-template-5.yml'),
           cfParams: {
             TableName: 'TestTable'
-          },
+          }
         })
                     .then(function (data) {
                       createStackStub.stub.should.not.be.called()
@@ -251,7 +251,7 @@ describe('create/update', function () {
                             ParameterValue: 'TestTable'
                           }
                         ],
-                        Tags: [],
+                        Tags: []
                       })
                       return data
                     })

--- a/test/index.js
+++ b/test/index.js
@@ -268,20 +268,20 @@ describe('create/update', function () {
             testParam: 'FOR-JS-TEMPLATE'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.not.be.called()
-                      updateStackStub.stub.should.be.calledOnce()
-                      updateStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'readCap',
-                            ParameterValue: '1'
-                          }
-                        ]
-                      })
-                      updateStackStub.stub.firstCall.args[0].TemplateBody.should.match(/"TableName":"TEST-TABLE-6-FOR-JS-TEMPLATE"/)
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.not.be.called()
+          updateStackStub.stub.should.be.calledOnce()
+          updateStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'readCap',
+                ParameterValue: '1'
+              }
+            ]
+          })
+          updateStackStub.stub.firstCall.args[0].TemplateBody.should.match(/"TableName":"TEST-TABLE-6-FOR-JS-TEMPLATE"/)
+          return data
+        })
       })
     })
     describe('if stack does not exist', function () {
@@ -293,11 +293,11 @@ describe('create/update', function () {
       it('creates json stack from file without parameters', function () {
         var cfn = require('../')
         return cfn('TEST-JSON-TEMPLATE', path.join(__dirname, '/templates/test-template-1.json'))
-                    .then(function (data) {
-                      createStackStub.stub.should.be.calledOnce()
-                      updateStackStub.stub.should.not.be.called()
-                      return data
-                    })
+                .then(function (data) {
+                  createStackStub.stub.should.be.calledOnce()
+                  updateStackStub.stub.should.not.be.called()
+                  return data
+                })
       })
       it('creates stack from yaml template string without parameters', function () {
         var cfn = require('../')
@@ -320,11 +320,11 @@ describe('create/update', function () {
                             "        WriteCapacityUnits: '1'\n" +
                             '      TableName: TEST-TABLE-6'
                 )
-                    .then(function (data) {
-                      createStackStub.stub.should.be.calledOnce()
-                      updateStackStub.stub.should.not.be.called()
-                      return data
-                    })
+                .then(function (data) {
+                  createStackStub.stub.should.be.calledOnce()
+                  updateStackStub.stub.should.not.be.called()
+                  return data
+                })
       })
       it('creates stack from json template file with CloudFormation parameters', function () {
         var cfn = require('../')
@@ -335,19 +335,19 @@ describe('create/update', function () {
             TableName: 'TestTable'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.be.calledOnce()
-                      createStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'TableName',
-                            ParameterValue: 'TestTable'
-                          }
-                        ]
-                      })
-                      updateStackStub.stub.should.not.be.called()
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.be.calledOnce()
+          createStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'TableName',
+                ParameterValue: 'TestTable'
+              }
+            ]
+          })
+          updateStackStub.stub.should.not.be.called()
+          return data
+        })
       })
       it('creates stack from yaml template file with CloudFormation parameters', function () {
         var cfn = require('../')
@@ -358,19 +358,19 @@ describe('create/update', function () {
             TableName: 'TestTable'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.be.calledOnce()
-                      createStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'TableName',
-                            ParameterValue: 'TestTable'
-                          }
-                        ]
-                      })
-                      updateStackStub.stub.should.not.be.called()
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.be.calledOnce()
+          createStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'TableName',
+                ParameterValue: 'TestTable'
+              }
+            ]
+          })
+          updateStackStub.stub.should.not.be.called()
+          return data
+        })
       })
       it('creates stack from yaml template file with CloudFormation parameters', function () {
         var cfn = require('../')
@@ -381,19 +381,19 @@ describe('create/update', function () {
             TableName: 'TestTable'
           }
         })
-                    .then(function (data) {
-                      createStackStub.stub.should.be.calledOnce()
-                      createStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'TableName',
-                            ParameterValue: 'TestTable'
-                          }
-                        ]
-                      })
-                      updateStackStub.stub.should.not.be.called()
-                      return data
-                    })
+        .then(function (data) {
+          createStackStub.stub.should.be.calledOnce()
+          createStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'TableName',
+                ParameterValue: 'TestTable'
+              }
+            ]
+          })
+          updateStackStub.stub.should.not.be.called()
+          return data
+        })
       })
       it('creates stack from js module file with module and CloudFormation parameters', function () {
         var cfn = require('../')
@@ -407,20 +407,20 @@ describe('create/update', function () {
             testParam: 'FOR-JS-TEMPLATE'
           }
         })
-                    .then(function (data) {
-                      updateStackStub.stub.should.not.be.called()
-                      createStackStub.stub.should.be.calledOnce()
-                      createStackStub.stub.should.be.calledWithMatch({
-                        Parameters: [
-                          {
-                            ParameterKey: 'readCap',
-                            ParameterValue: '1'
-                          }
-                        ]
-                      })
-                      createStackStub.stub.firstCall.args[0].TemplateBody.should.match(/"TableName":"TEST-TABLE-6-FOR-JS-TEMPLATE"/)
-                      return data
-                    })
+        .then(function (data) {
+          updateStackStub.stub.should.not.be.called()
+          createStackStub.stub.should.be.calledOnce()
+          createStackStub.stub.should.be.calledWithMatch({
+            Parameters: [
+              {
+                ParameterKey: 'readCap',
+                ParameterValue: '1'
+              }
+            ]
+          })
+          createStackStub.stub.firstCall.args[0].TemplateBody.should.match(/"TableName":"TEST-TABLE-6-FOR-JS-TEMPLATE"/)
+          return data
+        })
       })
     })
   })


### PR DESCRIPTION
Great project to simplify and track CloudFormation deployments! I needed the ability to tag my CF templates resources at the template level so I added it. Thanks for considering merging it back in! 