### PR TITLE
Avoid throttling of cf describeStackEvents api calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,18 @@ function Cfn (name, template) {
             .then(function (data) {
               next = (data || {}).NextToken
               allEvents = allEvents.concat(data.StackEvents)
-              return !next ? Promise.resolve() : getStackEvents()
+              return next && !allRelevantEventsLoaded(data.StackEvents) ? getStackEvents() : Promise.resolve()
             })
         }
         return getStackEvents().then(function () {
           return allEvents
         })
+      }
+
+      // events are loaded sorted by timestamp desc (newest events first)
+      // if we try to load all events we can easily run into throttling by aws api
+      function allRelevantEventsLoaded (events) {
+        return events.some(event => moment(event.Timestamp).valueOf() < startedAt)
       }
 
       interval = setInterval(function () {
@@ -221,6 +227,7 @@ function Cfn (name, template) {
             }
             // if throttling has occurred, process events again
             if (err && throttling.test(err)) {
+              log('AWS api calls are throttling')
               return _processEvents(events)
             }
             // otherwise, notify of failure

--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ function Cfn (name, template) {
         return events.some(event => moment(event.Timestamp).valueOf() < startedAt)
       }
 
-      interval = setInterval(function () {
+      function outputNewStackEvents () {
         let events = []
 
         if (running) {
@@ -235,7 +235,11 @@ function Cfn (name, template) {
               return _failure(err)
             }
           })
-      }, checkStackInterval)
+      }
+
+      // call once and repeat in intervals
+      outputNewStackEvents()
+      interval = setInterval(outputNewStackEvents, checkStackInterval)
     })
   }
 


### PR DESCRIPTION
Problem: Currently all events are loaded, even old once. As the event
history is long the api calls could page a few times and run into
throttling. Updating multiple stacks in parallel (e.g. on CI) can
easily cause throttling in an endless loop.

Events are loaded sorted by timestamp desc (newest events first).
So we do not need to load all of them, but can stop if we loaded an
event older than the starting time of our stack creation/update.