### PR TITLE
Avoid initial wait interval until first checking for events

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function Cfn (name, template) {
         })
       }
 
-      interval = setInterval(function () {
+      function outputNewStackEvents () {
         let events = []
 
         if (running) {
@@ -228,7 +228,11 @@ function Cfn (name, template) {
               return _failure(err)
             }
           })
-      }, checkStackInterval)
+      }
+
+      // call once and repeat in intervals
+      outputNewStackEvents()
+      interval = setInterval(outputNewStackEvents, checkStackInterval)
     })
   }
 


### PR DESCRIPTION
In case the stack did not need any updates, the tool waited for
'checkStackInterval' until it continues. By calling
'outputNewStackEvents' initially we avoid this unnecessary waiting.