### PR TITLE
Add support to number parameters in cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ function Cfn (name, template) {
 
     // mutate params
     _.keys(params).forEach(k => {
-      params[_.toLower(k)] = params[k]
+      params[_.toLower(k)] = _.toString(params[k])
     })
     return cf.getTemplateSummary(templateObject).promise()
       .then(data => {


### PR DESCRIPTION
Currently `meow` will convert any number parameters given into cfn cli into numbers.

`cfn deploy some-stack  sometemplate.yml --foo="bar" --max="2"`

gets converted to 

```js
{
  foo: 'bar',
  max: 2
}
```

This creates a problem when it is passed onto cf.update and cf.create as it is expecting all parameter values to be Strings as they are internally converted to the respective types inside the SDK.

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudFormation.html#createStack-property

